### PR TITLE
New: add css-validator command line client

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,7 @@ module.exports = function(grunt) {
         globals: {
           exports: true,
           describe: true,
+          after: true,
           before: true,
           it: true
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     jshint: {
-      files: ['Gruntfile.js', 'lib/**/*.js', 'test/**/*.js'],
+      files: ['Gruntfile.js', 'bin/**/*', 'lib/**/*.js', 'test/**/*.js'],
       options: {
         curly: true,
         eqeqeq: true,

--- a/bin/css-validator
+++ b/bin/css-validator
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+`echo eval exec node $(printf %q\  "$0" "$@")`
+const fs = require('fs')
+const validateCss = require('css-validator')
+
+validateCss({text: fs.readFileSync(process.argv[2])}, (err, data) => {
+  if (err) console.error(err)
+  if (data.errors.length) console.error(data.errors)
+  if (data.warnings.length) console.error(data.warnings)
+
+  process.exit(err || !data.validity || data.errors || data.warnings)
+})

--- a/bin/css-validator
+++ b/bin/css-validator
@@ -1,12 +1,97 @@
-#!/usr/bin/env bash
-`echo eval exec node $(printf %q\  "$0" "$@")`
-const fs = require('fs')
-const validateCss = require('css-validator')
+#!/usr/bin/env node
+var fs = require('fs');
 
-validateCss({text: fs.readFileSync(process.argv[2])}, (err, data) => {
-  if (err) console.error(err)
-  if (data.errors.length) console.error(data.errors)
-  if (data.warnings.length) console.error(data.warnings)
+var program = require('commander');
+var sleep = require('sleep');
 
-  process.exit(err || !data.validity || data.errors || data.warnings)
-})
+var ValidationStream = require('../lib/validation-stream');
+var package = require('../package.json');
+var validateCss = require('../lib/css-validator');
+
+var DEFAULT_VALIDATOR_URI = ValidationStream.w3cUrl;
+var DEFAULT_SLEEP_MILLIS = 100;
+
+var STATUS_OK = 0;
+var STATUS_WARN = 1;
+var STATUS_ERR = 2;
+var STATUS_INVALID = 3;
+
+function parseArgv(argv) {
+  program
+    .version(package.version)
+    .usage('[options] <file ...>') // todo: accept directories
+    .option('-e, --endpoint <URI>', 'address of the CSS validator service; defaults to ' + DEFAULT_VALIDATOR_URI,
+      DEFAULT_VALIDATOR_URI)
+    // Sleep between calls is recommend: https://jigsaw.w3.org/css-validator/about.html#api
+    .option('-s, --sleep [millis]',
+      'milliseconds to sleep after each file is validated to avoid service blacklisting; defaults to ' + DEFAULT_SLEEP_MILLIS + 'ms',
+      DEFAULT_SLEEP_MILLIS)
+    .parse(argv);
+}
+
+function onError(err) {
+  throw err;
+}
+
+function onData(data) {
+  // todo: pretty formatting and coloring.
+
+  if (data.warnings.length) {
+    console.error(data.warnings);
+  }
+
+  if (data.errors.length) {
+    console.error(data.errors);
+  } else if (!data.validity) {
+    console.error('Data is invalid');
+  }
+}
+
+function onEnd(sleepMillis) {
+  if (sleepMillis) {
+    sleep.msleep(sleepMillis);
+  }
+}
+
+function validate(endpoint, sleepMillis, css) {
+  return validateCss({text: css, w3cUrl: endpoint})
+    .on('error', onError)
+    .on('data', onData)
+    .on('end', onEnd.bind(null, sleepMillis));
+}
+
+function validateFiles(endpoint, sleepMillis, files, status) {
+  var file = files.pop();
+  if (!file) {
+    process.exit(status);
+  }
+
+  console.log(file);
+  var css = fs.readFileSync(file);
+  validate(endpoint, sleepMillis, css)
+    .on('data', function(data) {
+      if (data.warnings.length) {
+        status = Math.max(STATUS_WARN, status);
+      }
+
+      if (data.errors.length) {
+        status = Math.max(STATUS_ERR, status);
+      } else if (!data.validity) {
+        status = Math.max(STATUS_INVALID, status);
+      }
+    })
+    .on('end', function() {
+      validateFiles(endpoint, sleepMillis, files, status);
+    });
+}
+
+function main(argv) {
+  var files;
+
+  parseArgv(argv);
+  files = program.args;
+
+  return validateFiles(program.endpoint, program.sleep, files, STATUS_OK);
+}
+
+main(process.argv);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "foundry-release-git": "~2.0.2",
     "foundry-release-npm": "~2.0.2",
     "grunt": "~0.4.1",
+    "grunt-cli": "~1.2.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-watch": "~0.4.0",
     "mocha": "~1.11.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "engines": {
     "node": ">= 0.8.0"
   },
+  "bin": {
+    "css-validator": "bin/css-validator"
+  },
   "scripts": {
     "test": "mocha"
   },

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "test": "mocha"
   },
   "dependencies": {
+    "commander": "~2.9.0",
+    "form-data": "~0.1.2",
     "obj-extend": "~0.1.0",
-    "sax": "~0.5.5",
     "readable-stream": "~1.1.9",
-    "form-data": "~0.1.2"
+    "sax": "~0.5.5",
+    "sleep": "~5.1.0"
   },
   "devDependencies": {
     "chai": "~1.8.1",


### PR DESCRIPTION
Add initial pass at a CLI to css-validator. This unblocks users wanting
an NPM script option like html-validator offers.